### PR TITLE
chore: bump version to 0.0.8 and auto-activate on VS Code startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension",
   "displayName": "88Code 插件",
   "description": "88Code API 管理插件",
-  "version": "0.0.7",
+  "version": "0.8.0",
   "publisher": "88code",
   "repository": {
     "type": "git",
@@ -15,6 +15,9 @@
     "Other"
   ],
   "main": "./out/extension.js",
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "contributes": {
     "viewsContainers": {
       "activitybar": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-extension",
   "displayName": "88Code 插件",
   "description": "88Code API 管理插件",
-  "version": "0.8.0",
+  "version": "0.0.8",
   "publisher": "88code",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version to 0.8.0 and add activationEvents: onStartupFinished to auto-activate on VS Code startup.